### PR TITLE
Log per-label metrics in MLflow

### DIFF
--- a/src/solver/det_solver.py
+++ b/src/solver/det_solver.py
@@ -222,7 +222,7 @@ class DetSolver(BaseSolver):
 
             if self.use_mlflow:
                 logs = {
-                    f"metrics/{metric_names[idx]}": test_stats["coco_eval_bbox"][idx]
+                    f"val/{metric_names[idx]}": test_stats["coco_eval_bbox"][idx]
                     for idx in range(len(metric_names))
                 }
                 logs["epoch"] = epoch

--- a/src/solver/validator.py
+++ b/src/solver/validator.py
@@ -53,17 +53,25 @@ class Validator:
             fns += value["FNs"]
             ious.extend(value["IoUs"])
 
-            extended_metrics[f"precision_{key}"] = (
+            precision = (
                 value["TPs"] / (value["TPs"] + value["FPs"])
                 if value["TPs"] + value["FPs"] > 0
                 else 0
             )
-            extended_metrics[f"recall_{key}"] = (
+            recall = (
                 value["TPs"] / (value["TPs"] + value["FNs"])
                 if value["TPs"] + value["FNs"] > 0
                 else 0
             )
+            f1 = (
+                2 * precision * recall / (precision + recall)
+                if (precision + recall) > 0
+                else 0
+            )
 
+            extended_metrics[f"precision_{key}"] = precision
+            extended_metrics[f"recall_{key}"] = recall
+            extended_metrics[f"f1_{key}"] = f1
             extended_metrics[f"iou_{key}"] = np.mean(value["IoUs"])
 
         precision = tps / (tps + fps) if (tps + fps) > 0 else 0


### PR DESCRIPTION
## Summary
- log precision, recall, f1, and IoU per class to MLflow alongside aggregated scores
- prefix MLflow metric names with train/ and val/ for clarity

## Testing
- `pre-commit run --files src/solver/validator.py src/solver/det_engine.py src/solver/det_solver.py`
- `python -m pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1640d92c0832480c8f8e5b157390c