### PR TITLE
Add final test-set evaluation for best checkpoints

### DIFF
--- a/src/core/yaml_config.py
+++ b/src/core/yaml_config.py
@@ -24,6 +24,7 @@ class YAMLConfig(BaseConfig):
         cfg = merge_dict(cfg, kwargs)
 
         self.yaml_cfg = copy.deepcopy(cfg)
+        self._test_dataloader = None
 
         for k in super().__dict__:
             if not k.startswith("_") and k in cfg:
@@ -84,6 +85,14 @@ class YAMLConfig(BaseConfig):
         if self._val_dataloader is None and "val_dataloader" in self.yaml_cfg:
             self._val_dataloader = self.build_dataloader("val_dataloader")
         return super().val_dataloader
+
+    @property
+    def test_dataloader(self) -> DataLoader:
+        if hasattr(self, "_test_dataloader") is False:
+            self._test_dataloader = None
+        if self._test_dataloader is None and "test_dataloader" in self.yaml_cfg:
+            self._test_dataloader = self.build_dataloader("test_dataloader")
+        return self._test_dataloader
 
     @property
     def ema(self) -> torch.nn.Module:

--- a/src/solver/_solver.py
+++ b/src/solver/_solver.py
@@ -168,6 +168,12 @@ class BaseSolver(object):
         self.val_dataloader = dist_utils.warp_loader(
             self.cfg.val_dataloader, shuffle=self.cfg.val_dataloader.shuffle
         )
+        if getattr(self.cfg, "test_dataloader", None) is not None:
+            self.test_dataloader = dist_utils.warp_loader(
+                self.cfg.test_dataloader, shuffle=self.cfg.test_dataloader.shuffle
+            )
+        else:
+            self.test_dataloader = None
 
         self.evaluator = self.cfg.evaluator
 


### PR DESCRIPTION
## Summary
- support optional `test_dataloader` config
- evaluate best checkpoint and ONNX export on test set after training
- log test metrics to MLFlow

## Testing
- `pre-commit run --files src/core/yaml_config.py src/solver/_solver.py src/solver/det_engine.py src/solver/det_solver.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c16488db888324b598f92a051a7b40