### PR TITLE
Fix MLflow metric logging with nested metrics

### DIFF
--- a/src/solver/det_engine.py
+++ b/src/solver/det_engine.py
@@ -232,7 +232,10 @@ def evaluate(
             if k == "extended_metrics":
                 for mk, mv in v.items():
                     base, label = mk.split("_", 1)
-                    log_metrics[f"val/{base}/{label}"] = mv
+                    # Replace nested slashes with an underscore to
+                    # avoid creating conflicting directories in the
+                    # mlflow metrics store.
+                    log_metrics[f"val/{base}_{label}"] = mv
             else:
                 log_metrics[f"val/{k}"] = v
         mlflow.log_metrics(log_metrics, step=epoch)


### PR DESCRIPTION
## Summary
- avoid nested metric paths when logging extended metrics to MLflow

## Testing
- `python -m py_compile src/solver/det_engine.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c169953f6c8324b1db0857376e894c