### PR TITLE
Fix PIL image type check in data loader

### DIFF
--- a/src/data/dataloader.py
+++ b/src/data/dataloader.py
@@ -68,7 +68,7 @@ def batch_image_collate_fn(items):
     images = []
     targets = []
     for img, tgt in items:
-        if isinstance(img, PILImage):
+        if isinstance(img, PILImage.Image):
             img = VF.pil_to_tensor(img)
             img = img.float().div(255.0)
             img = Image(img)
@@ -120,7 +120,7 @@ class BatchImageCollateFunction(BaseCollateFunction):
         images = []
         targets = []
         for img, tgt in items:
-            if isinstance(img, PILImage):
+            if isinstance(img, PILImage.Image):
                 img = VF.pil_to_tensor(img)
                 img = img.float().div(255.0)
                 img = Image(img)


### PR DESCRIPTION
## Summary
- use `PILImage.Image` when checking for PIL images in collate functions to avoid TypeError

## Testing
- `pre-commit run --files src/data/dataloader.py`
- `python -m py_compile src/data/dataloader.py`


------
https://chatgpt.com/codex/tasks/task_e_68c17230471083248a114d8a5446e35c