### PR TITLE
Add ONNX evaluation visualizations

### DIFF
--- a/src/solver/det_solver.py
+++ b/src/solver/det_solver.py
@@ -275,13 +275,14 @@ class DetSolver(BaseSolver):
                         self.device,
                         epoch=self.last_epoch,
                         use_mlflow=self.use_mlflow,
+                        output_dir=self.output_dir,
                     )
                     if self.use_mlflow and "coco_eval_bbox" in onnx_stats:
                         logs = {f"test/onnx/{metric_names[i]}": onnx_stats["coco_eval_bbox"][i]
                                 for i in range(len(metric_names))}
                         logs["epoch"] = self.last_epoch
                         self.mlflow.log_metrics(logs, step=self.last_epoch)
-        
+
         # -----------------------------------------------------------
 
         if self.use_mlflow:


### PR DESCRIPTION
## Summary
- expand Validator.save_plots with confusion matrix, normalized matrix, PR/F1/precision/recall curves
- generate and log ONNX evaluation plots during evaluate_onnx
- pass output directory to ONNX evaluator to store artifacts

## Testing
- `pre-commit run --files src/solver/validator.py src/solver/det_engine.py src/solver/det_solver.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4202103ec8324a05167f20bd3785c